### PR TITLE
Add ability to map ports into container

### DIFF
--- a/docs/gitbook/getting_started/activate_component.md
+++ b/docs/gitbook/getting_started/activate_component.md
@@ -17,6 +17,19 @@ $ docker ps
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ```
 
+## Setup hostname
+
+In our `maelstrom.yml` we used the hostname `hello.localhost`. Let's add that to `/etc/hosts` so our 
+computer can resolve it.
+
+```bash
+sudo bash -c "echo '127.0.0.1  hello.localhost' >> /etc/hosts"
+```
+
+Note: If you're running `dnsmasq` you may not need to perform the above step, as it sets up a wildcard
+DNS entry for `*.localhost` automatically. Trying pinging `hello.localhost` first and if it doesn't resolve,
+run the command above.
+
 ## Make a request
 
 `maelstromd` is running on port 8008 (because of `MAEL_PUBLICPORT=8008` in `mael.env`).

--- a/idl/maelstrom.idl
+++ b/idl/maelstrom.idl
@@ -247,6 +247,11 @@ struct DockerComponent {
     // the docker container is stopped and removed.  (default=300)
     idleTimeoutSeconds           int     [optional]
 
+    // Optional list of ports to expose from the container
+    // The httpPort specified above will be automatically mapped and should not be
+    // included in this list.
+    ports                    []string       [optional]
+
     // List of filesystem mounts to bind to container
     // Use we care, as you must ensure these paths exist on any host in the maelstrom cluster
     volumes                  []VolumeMount  [optional]

--- a/pkg/maelstrom/project.go
+++ b/pkg/maelstrom/project.go
@@ -148,6 +148,7 @@ type yamlComponent struct {
 	HttpStartHealthCheckSeconds int64
 	HttpHealthCheckSeconds      int64
 	IdleTimeoutSeconds          int64
+	Ports                       []string
 	Volumes                     []v1.VolumeMount
 	NetworkName                 string
 	LogDriver                   string
@@ -202,6 +203,7 @@ func (c yamlComponent) toComponentWithEventSources(name string, projectName stri
 				HttpStartHealthCheckSeconds: c.HttpStartHealthCheckSeconds,
 				HttpHealthCheckSeconds:      c.HttpHealthCheckSeconds,
 				IdleTimeoutSeconds:          c.IdleTimeoutSeconds,
+				Ports:                       c.Ports,
 				Volumes:                     c.Volumes,
 				NetworkName:                 c.NetworkName,
 				LogDriver:                   c.LogDriver,


### PR DESCRIPTION
Useful if you want to expose debugging ports, for example.
Probably not useful in non-dev environments.

Also fix a small doc issue re: DNS