### PR TITLE
Add MAEL_TOTALMEMORY env var to allow nodes to use a subset of system memory

### DIFF
--- a/cmd/maelstromd/maelstromd.go
+++ b/cmd/maelstromd/maelstromd.go
@@ -152,7 +152,8 @@ func main() {
 	dockerMonitor := common.NewDockerImageMonitor(dockerClient, handlerFactory, cancelCtx)
 	dockerMonitor.RunAsync(daemonWG)
 
-	nodeSvcImpl, err := maelstrom.NewNodeServiceImplFromDocker(handlerFactory, db, dockerClient, peerUrl)
+	nodeSvcImpl, err := maelstrom.NewNodeServiceImplFromDocker(handlerFactory, db, dockerClient, peerUrl,
+		conf.TotalMemory)
 	if err != nil {
 		log.Error("maelstromd: cannot create NodeService", "err", err)
 		os.Exit(2)

--- a/docs/gitbook/appendix/maelstromd_env_vars.md
+++ b/docs/gitbook/appendix/maelstromd_env_vars.md
@@ -27,6 +27,12 @@
 |---------------------------------|----------------------------------------------|-----------|---------|
 | MAEL_CRONREFRESHSECONDS         | Interval to reload cron rules from db        | No        | 60      |
 
+## System Resources
+
+| Variable                  | Description                                  | Required? | Default                 |
+|---------------------------|----------------------------------------------|-----------|-------------------------|
+| MAEL_TOTALMEMORY          | Memory (MiB) to make available to containers | No        | System total memory     |
+
 ## Debugging
 
 | Variable                        | Description                                  | Required? | Default |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,6 +75,8 @@ type Config struct {
 	LogGCSeconds int
 	// If set, log profile data to this filename
 	CpuProfileFilename string
+	// Memory (MiB) to make available to containers (if set to zero, maelstromd will simply act as a relay)
+	TotalMemory int64 `default:"-1"`
 
 	// Currently unsupported - will dust these off in the future
 	Cluster      ClusterOptions

--- a/pkg/maelstrom/fixture_test.go
+++ b/pkg/maelstrom/fixture_test.go
@@ -131,7 +131,7 @@ func newFixture(t *testing.T, dockerClient *docker.Client, sqlDb *SqlDb) *Fixtur
 	hFactory, err := NewDockerHandlerFactory(dockerClient, resolver, sqlDb, ctx, testGatewayPort)
 	assert.Nil(t, err, "NewDockerHandlerFactory err != nil: %v", err)
 
-	nodeSvcImpl, err := NewNodeServiceImplFromDocker(hFactory, sqlDb, dockerClient, "")
+	nodeSvcImpl, err := NewNodeServiceImplFromDocker(hFactory, sqlDb, dockerClient, "", -1)
 	assert.Nil(t, err, "NewNodeServiceImplFromDocker err != nil: %v", err)
 
 	router := NewRouter(nodeSvcImpl, hFactory, nodeSvcImpl.nodeId, outboundIp.String(), ctx)


### PR DESCRIPTION
If set to zero no memory will be made available to maelstrom, allowing
the node to be used as a local request router.