### PR TITLE
sqs: ramp up poller concurrency with the # of running instances

### DIFF
--- a/pkg/maelstrom/router.go
+++ b/pkg/maelstrom/router.go
@@ -84,6 +84,16 @@ func (r *Router) GetNodeService() v1.NodeService {
 	return r.nodeService
 }
 
+func (r *Router) InstanceCountForComponent(componentName string) int {
+	r.lock.Lock()
+	ring, ok := r.ringByComponent[componentName]
+	r.lock.Unlock()
+	if ok {
+		return len(ring.handlers)
+	}
+	return 0
+}
+
 func (r *Router) OnClusterUpdated(nodes map[string]v1.NodeStatus) {
 	newRing := map[string]*componentRing{}
 	componentNames := make([]string, 0)


### PR DESCRIPTION
This helps avoid dequeueing too many messages at one time, which can
easily lead to visibility timeout issues and duplicate delivery.