### PR TITLE
maelstromd: concurrently provision each component in series

### DIFF
--- a/idl/maelstrom.idl
+++ b/idl/maelstrom.idl
@@ -242,6 +242,7 @@ struct Component {
 struct DockerComponent {
     image                   string
     command                 []string     [optional]
+    entrypoint              []string     [optional]
     httpPort                int
     httpHealthCheckPath     string
 

--- a/pkg/maelstrom/fixture_test.go
+++ b/pkg/maelstrom/fixture_test.go
@@ -210,7 +210,7 @@ func (f *Fixture) makeHttpRequest(url string) *httptest.ResponseRecorder {
 	req, err := http.NewRequest("GET", url, nil)
 	rw := httptest.NewRecorder()
 	assert.Nil(f.t, err, "http.NewRequest err != nil: %v", err)
-	f.router.Route(rw, req, f.component)
+	f.router.Route(rw, req, f.component, false)
 	return rw
 }
 

--- a/pkg/maelstrom/gateway.go
+++ b/pkg/maelstrom/gateway.go
@@ -36,10 +36,7 @@ func (g *Gateway) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// TODO: need to look for a request header with deadline and adjust accordingly
-	// should only look for header if gateway is private
-
-	g.router.Route(rw, req, comp)
+	g.router.Route(rw, req, comp, g.public)
 }
 
 func respondText(rw http.ResponseWriter, statusCode int, body string) {

--- a/pkg/maelstrom/handler.go
+++ b/pkg/maelstrom/handler.go
@@ -497,7 +497,7 @@ func startContainer(dockerClient *docker.Client, c v1.Component, maelstromUrl st
 	}
 
 	log.Info("handler: starting container", "component", c.Name, "ver", c.Version, "containerId", resp.ID[0:8],
-		"image", config.Image, "command", config.Cmd)
+		"image", config.Image, "command", config.Cmd, "entrypoint", config.Entrypoint)
 
 	err = dockerClient.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})
 	if err != nil {
@@ -561,9 +561,10 @@ func toContainerConfig(c v1.Component, maelstromUrl string) *container.Config {
 	env = append(env, fmt.Sprintf("MAELSTROM_COMPONENT_VERSION=%d", c.Version))
 
 	return &container.Config{
-		Image: c.Docker.Image,
-		Cmd:   c.Docker.Command,
-		Env:   env,
+		Image:      c.Docker.Image,
+		Cmd:        c.Docker.Command,
+		Entrypoint: c.Docker.Entrypoint,
+		Env:        env,
 		ExposedPorts: nat.PortSet{
 			nat.Port(strconv.Itoa(int(c.Docker.HttpPort)) + "/tcp"): struct{}{},
 		},

--- a/pkg/maelstrom/project.go
+++ b/pkg/maelstrom/project.go
@@ -136,6 +136,7 @@ func mapToNameValues(m map[string]string) []v1.NameValue {
 type yamlComponent struct {
 	Image                       string
 	Command                     []string
+	Entrypoint                  []string
 	Environment                 []string
 	MinInstances                int64
 	MaxInstances                int64
@@ -201,6 +202,7 @@ func (c yamlComponent) toComponentWithEventSources(name string, projectName stri
 			Docker: &v1.DockerComponent{
 				Image:                       c.Image,
 				Command:                     c.Command,
+				Entrypoint:                  c.Entrypoint,
 				HttpPort:                    c.HttpPort,
 				HttpHealthCheckPath:         c.HttpHealthCheckPath,
 				HttpStartHealthCheckSeconds: c.HttpStartHealthCheckSeconds,

--- a/pkg/maelstrom/sqs.go
+++ b/pkg/maelstrom/sqs.go
@@ -74,7 +74,7 @@ func (s *SqsPoller) Run(concurrency int) {
 					log.Error("sqs: error creating http req", "err", err, "queueUrl", m.queueUrl)
 				} else {
 					rw := httptest.NewRecorder()
-					s.router.Route(rw, req, *m.component)
+					s.router.Route(rw, req, *m.component, false)
 					if rw.Code == 200 {
 						if log.IsDebug() {
 							log.Debug("sqs: deleting message", "queueUrl", m.queueUrl)


### PR DESCRIPTION
Also:
* support entrypoint on components
* only look for deadline header if request is non-public
* add recover to revproxy to avoid panics if calling ServeHTTP is closed