### PR TITLE
autoscale: track start time of container and use in autoscale path

### DIFF
--- a/idl/maelstrom.idl
+++ b/idl/maelstrom.idl
@@ -473,6 +473,7 @@ struct ComponentInfo {
     componentVersion   int
     maxConcurrency     int
     memoryReservedMiB  int
+    startTime          int
     lastRequestTime    int
     totalRequests      int
     activity           []ComponentActivity

--- a/pkg/common/docker.go
+++ b/pkg/common/docker.go
@@ -217,7 +217,7 @@ func StartContainer(dockerClient *docker.Client, c *v1.Component, maelstromUrl s
 		return "", fmt.Errorf("containerCreate error for: %s - %v", c.Name, err)
 	}
 
-	log.Info("handler: starting container", "component", c.Name, "ver", c.Version, "containerId", resp.ID[0:8],
+	log.Info("common: starting container", "component", c.Name, "ver", c.Version, "containerId", resp.ID[0:8],
 		"image", config.Image, "command", config.Cmd, "entrypoint", config.Entrypoint)
 
 	err = dockerClient.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})

--- a/pkg/common/math.go
+++ b/pkg/common/math.go
@@ -1,0 +1,15 @@
+package common
+
+func MaxInt64(vals ...int64) int64 {
+	if len(vals) == 0 {
+		return 0
+	}
+
+	max := vals[0]
+	for i := 1; i < len(vals); i++ {
+		if vals[i] > max {
+			max = vals[i]
+		}
+	}
+	return max
+}

--- a/pkg/maelstrom/component/container.go
+++ b/pkg/maelstrom/component/container.go
@@ -52,6 +52,7 @@ func NewContainer(dockerClient *docker.Client, component *v1.Component, maelstro
 		statLock:               &sync.Mutex{},
 		component:              component,
 		maelstromUrl:           maelstromUrl,
+		startTime:              time.Now(),
 		lastReqTime:            time.Time{},
 		totalRequests:          0,
 		activity:               make([]v1.ComponentActivity, 0),
@@ -95,6 +96,7 @@ type Container struct {
 	statLock *sync.Mutex
 
 	// activity stats
+	startTime     time.Time
 	lastReqTime   time.Time
 	totalRequests int64
 	activity      []v1.ComponentActivity
@@ -112,6 +114,7 @@ func (c *Container) ComponentInfo() v1.ComponentInfo {
 		ComponentVersion:  c.component.Version,
 		MaxConcurrency:    c.component.MaxConcurrency,
 		MemoryReservedMiB: c.component.Docker.ReserveMemoryMiB,
+		StartTime:         common.TimeToMillis(c.startTime),
 		LastRequestTime:   common.TimeToMillis(c.lastReqTime),
 		TotalRequests:     c.totalRequests,
 		Activity:          c.activity,

--- a/pkg/maelstrom/scale.go
+++ b/pkg/maelstrom/scale.go
@@ -108,9 +108,8 @@ func toComponentConcurrency(nodes []v1.NodeStatus, componentsByName map[string]v
 		for _, compInfo := range node.RunningComponents {
 			arr := compInfoByComponent[compInfo.ComponentName]
 			compInfoByComponent[compInfo.ComponentName] = append(arr, compInfo)
-			if compInfo.LastRequestTime > lastReqTimeByComponent[compInfo.ComponentName] {
-				lastReqTimeByComponent[compInfo.ComponentName] = compInfo.LastRequestTime
-			}
+			lastReqTimeByComponent[compInfo.ComponentName] = common.MaxInt64(compInfo.LastRequestTime,
+				compInfo.StartTime, lastReqTimeByComponent[compInfo.ComponentName])
 		}
 	}
 

--- a/pkg/v1/v1.go
+++ b/pkg/v1/v1.go
@@ -8,8 +8,8 @@ import (
 )
 
 const BarristerVersion string = "0.1.6"
-const BarristerChecksum string = "2841bd178563401bde1baadba8760162"
-const BarristerDateGenerated int64 = 1570718314011000000
+const BarristerChecksum string = "664d2fd5d7c3448db18e7f6e779a9211"
+const BarristerDateGenerated int64 = 1570746804595000000
 
 type EventSourceType string
 
@@ -134,6 +134,7 @@ type ComponentInfo struct {
 	ComponentVersion  int64               `json:"componentVersion"`
 	MaxConcurrency    int64               `json:"maxConcurrency"`
 	MemoryReservedMiB int64               `json:"memoryReservedMiB"`
+	StartTime         int64               `json:"startTime"`
 	LastRequestTime   int64               `json:"lastRequestTime"`
 	TotalRequests     int64               `json:"totalRequests"`
 	Activity          []ComponentActivity `json:"activity"`
@@ -1953,6 +1954,13 @@ var IdlJsonRaw = `[
                 "comment": ""
             },
             {
+                "name": "startTime",
+                "type": "int",
+                "optional": false,
+                "is_array": false,
+                "comment": ""
+            },
+            {
                 "name": "lastRequestTime",
                 "type": "int",
                 "optional": false,
@@ -3271,7 +3279,7 @@ var IdlJsonRaw = `[
         "values": null,
         "functions": null,
         "barrister_version": "0.1.6",
-        "date_generated": 1570718314011,
-        "checksum": "2841bd178563401bde1baadba8760162"
+        "date_generated": 1570746804595,
+        "checksum": "664d2fd5d7c3448db18e7f6e779a9211"
     }
 ]`


### PR DESCRIPTION
This should mitigate cases where the startup time is very long (due to long running pull, for example)
We may also opt to display start time in the ps output later on.