### PR TITLE
maelstromd: fix two deadlocks

### DIFF
--- a/pkg/maelstrom/evpoller.go
+++ b/pkg/maelstrom/evpoller.go
@@ -103,7 +103,11 @@ func (e *EvPoller) initSqsEventSource(es v1.EventSource, validRoleIds map[string
 		log.Error("evpoller: Unable to load component", "component", es.ComponentName, "err", err)
 		return
 	}
-	instancesRunning := e.dispatcher.InstanceCountForComponent(comp)
+	instancesRunning, err := e.dispatcher.InstanceCountForComponent(comp)
+	if err != nil {
+		log.Error("evpoller: Unable to get instance count for component", "component", es.ComponentName, "err", err)
+		return
+	}
 	roleIdConcurs := sqsRoleIdConcurrency(es, int(comp.MaxConcurrency), instancesRunning)
 	for _, rc := range roleIdConcurs {
 		roleId := rc.roleId

--- a/pkg/v1/v1.go
+++ b/pkg/v1/v1.go
@@ -9,7 +9,7 @@ import (
 
 const BarristerVersion string = "0.1.6"
 const BarristerChecksum string = "664d2fd5d7c3448db18e7f6e779a9211"
-const BarristerDateGenerated int64 = 1570751325586000000
+const BarristerDateGenerated int64 = 1571086745325000000
 
 type EventSourceType string
 
@@ -3279,7 +3279,7 @@ var IdlJsonRaw = `[
         "values": null,
         "functions": null,
         "barrister_version": "0.1.6",
-        "date_generated": 1570751325586,
+        "date_generated": 1571086745325,
         "checksum": "664d2fd5d7c3448db18e7f6e779a9211"
     }
 ]`


### PR DESCRIPTION
* notify goroutines waiting to send to localCh to abort when we're shutting down
  (fixes deadlock when shutdown is called due to failed component startup)

* Dispatcher.InstanceCountForComponent should only block on req.Output if
  trySend was successful (which it won't be during shutdown)