### PR TITLE
expose MAELSTROM_PROJECT_NAME to containers

### DIFF
--- a/pkg/common/docker.go
+++ b/pkg/common/docker.go
@@ -238,6 +238,7 @@ func toContainerConfig(c *v1.Component, maelstromUrl string) *container.Config {
 	env = append(env, fmt.Sprintf("MAELSTROM_PRIVATE_URL=%s", maelstromUrl))
 	env = append(env, fmt.Sprintf("MAELSTROM_COMPONENT_NAME=%s", c.Name))
 	env = append(env, fmt.Sprintf("MAELSTROM_COMPONENT_VERSION=%d", c.Version))
+	env = append(env, fmt.Sprintf("MAELSTROM_PROJECT_NAME=%s", c.ProjectName))
 
 	return &container.Config{
 		Image:      c.Docker.Image,


### PR DESCRIPTION
This allows application code to form project name relative
component names when doing component -> component requests.