### PR TITLE
maelstromd: add pullimageonstart option. implement pullimageonput support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MAEL_SQL_DSN = ./tmp/maelstrom.db?cache=shared&_journal_mode=MEMORY
 #MAEL_SQL_DSN = postgres://postgres:test@localhost:5432/mael?sslmode=disable
 MAEL_PUBLIC_PORT = 8008
 
-BUILD_VER = unreleased
+BUILD_VER = 0.0.0
 BUILD_DATE := $(shell date +%FT%T%z)
 BUILD_GITSHA := $(shell git rev-parse --short HEAD)
 LD_FLAGS = -ldflags "-X main.version=$(BUILD_VER) -X main.builddate=$(BUILD_DATE) -X main.gitsha=$(BUILD_GITSHA)"

--- a/docs/gitbook/appendix/project_yaml_ref.md
+++ b/docs/gitbook/appendix/project_yaml_ref.md
@@ -115,10 +115,32 @@ components:
 By default docker images are pulled without authentication. Each component may optionally specify registry auth
 credentials or provide a completely custom command to run on the host to pull the image.
 
+#### Floating tags
+
+If you use a floating tag (e.g. "latest") you should set `pullimageonstart: true` or `pullimageonput: true` to
+ensure that changes to the image are pulled. Otherwise maelstrom may continue to start containers with
+a stale version of the image.
+
+#### Pull before each start
+
+Images are always pulled if they do not exist locally, but are not pulled if the image already exists.
+If you want maelstrom to pull the image before starting any container for the component,
+set `pullimageonstart: true`.
+
+```yaml
+
+---
+name: myproject
+components:
+  component_name_1:
+    pullimageonstart: true
+```
+
 #### Pull after component put
 
-Images are always pulled before starting a container. To pull an image immediately after a component put operation,
-set `pullimageonput: true`.  This will pull the image immediately any time the component is modified.
+To pull an image immediately after a component put operation,
+set `pullimageonput: true`.  This will pull the image immediately any time the component is modified, including
+during a `project put` call that modifies the component.
 
 ```yaml
 

--- a/idl/maelstrom.idl
+++ b/idl/maelstrom.idl
@@ -326,8 +326,11 @@ struct DockerComponent {
 
     // If true, image will be pulled after each PutComponent call even if no containers
     // for this component are running. (default=false)
-    // Images are always pulled for a component when starting a container.
     pullImageOnPut      bool  [optional]
+
+    // If true, image will be pulled before starting a container. If false, image will
+    // be pulled before starting a container only if no image is present locally. (default=false)
+    pullImageOnStart    bool  [optional]
 }
 
 struct VolumeMount {

--- a/pkg/common/docker.go
+++ b/pkg/common/docker.go
@@ -141,6 +141,19 @@ func ResolveMaelstromHost(dockerClient *docker.Client) (string, error) {
 	return host, nil
 }
 
+func ImageExistsLocally(dockerClient *docker.Client, imageName string) (bool, error) {
+	filt := filters.NewArgs()
+	filt.Add("reference", NormalizeImageName(imageName))
+	images, err := dockerClient.ImageList(context.Background(), types.ImageListOptions{
+		All:     false,
+		Filters: filt,
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(images) > 0, nil
+}
+
 func ListMaelstromContainers(dockerClient *docker.Client) ([]types.Container, error) {
 	filter := filters.NewArgs()
 	filter.Add("label", "maelstrom=true")

--- a/pkg/maelstrom/component/pullstate.go
+++ b/pkg/maelstrom/component/pullstate.go
@@ -1,0 +1,41 @@
+package component
+
+import (
+	v1 "github.com/coopernurse/maelstrom/pkg/v1"
+	docker "github.com/docker/docker/client"
+	log "github.com/mgutz/logxi/v1"
+	"sync"
+)
+
+func NewPullState(dockerClient *docker.Client) *PullState {
+	return &PullState{
+		dockerClient:         dockerClient,
+		pulledVerByComponent: make(map[string]int64),
+		lock:                 &sync.Mutex{},
+	}
+}
+
+type PullState struct {
+	dockerClient         *docker.Client
+	pulledVerByComponent map[string]int64
+	lock                 *sync.Mutex
+}
+
+func (p *PullState) Pull(c v1.Component, forcePull bool) {
+	p.lock.Lock()
+	ver := p.pulledVerByComponent[c.Name]
+	p.lock.Unlock()
+
+	if ver != c.Version || forcePull {
+		err := pullImage(p.dockerClient, c)
+		if err != nil {
+			log.Warn("component: unable to pull image", "err", err.Error(), "component", c.Name,
+				"image", c.Docker.Image)
+		} else {
+			p.lock.Lock()
+			p.pulledVerByComponent[c.Name] = c.Version
+			p.lock.Unlock()
+			log.Info("component: successfully pulled image", "component", c.Name, "image", c.Docker.Image)
+		}
+	}
+}

--- a/pkg/maelstrom/fixture_test.go
+++ b/pkg/maelstrom/fixture_test.go
@@ -123,7 +123,7 @@ func newFixture(t *testing.T, dockerClient *docker.Client, sqlDb *SqlDb) *Fixtur
 	}
 
 	nodeSvcImpl, err := NewNodeServiceImplFromDocker(sqlDb, dockerClient, 8374, "", -1, "", shutdownCh, nil,
-		"")
+		"", component.NewPullState(dockerClient))
 	assert.Nil(t, err, "NewNodeServiceImplFromDocker err != nil: %v", err)
 
 	gateway := NewGateway(resolver, nodeSvcImpl.Dispatcher(), false, outboundIp.String())

--- a/pkg/maelstrom/project.go
+++ b/pkg/maelstrom/project.go
@@ -169,6 +169,7 @@ type yamlComponent struct {
 	PullUsername                string
 	PullPassword                string
 	PullImageOnPut              bool
+	PullImageOnStart            bool
 }
 
 func (c yamlComponent) toComponentWithEventSources(name string, projectName string,
@@ -257,6 +258,7 @@ func (c yamlComponent) toComponentWithEventSources(name string, projectName stri
 				PullUsername:                c.PullUsername,
 				PullPassword:                c.PullPassword,
 				PullImageOnPut:              c.PullImageOnPut,
+				PullImageOnStart:            c.PullImageOnStart,
 			},
 		},
 		EventSources: eventSources,

--- a/pkg/maelstrom/puller.go
+++ b/pkg/maelstrom/puller.go
@@ -1,0 +1,35 @@
+package maelstrom
+
+import (
+	"github.com/coopernurse/maelstrom/pkg/maelstrom/component"
+	v1 "github.com/coopernurse/maelstrom/pkg/v1"
+	docker "github.com/docker/docker/client"
+	log "github.com/mgutz/logxi/v1"
+)
+
+func NewImagePuller(dockerClient *docker.Client, db Db, pullState *component.PullState) *ImagePuller {
+	return &ImagePuller{
+		dockerClient: dockerClient,
+		db:           db,
+		pullState:    pullState,
+	}
+}
+
+type ImagePuller struct {
+	dockerClient *docker.Client
+	db           Db
+	pullState    *component.PullState
+}
+
+func (i *ImagePuller) OnComponentNotification(change v1.DataChangedUnion) {
+	if change.PutComponent != nil {
+		comp, err := i.db.GetComponent(change.PutComponent.Name)
+		if err == nil {
+			if comp.Docker.PullImageOnPut {
+				i.pullState.Pull(comp, false)
+			}
+		} else {
+			log.Error("puller: unable to GetComponent", "err", err, "component", change.PutComponent.Name)
+		}
+	}
+}

--- a/pkg/v1/v1.go
+++ b/pkg/v1/v1.go
@@ -8,8 +8,8 @@ import (
 )
 
 const BarristerVersion string = "0.1.6"
-const BarristerChecksum string = "664d2fd5d7c3448db18e7f6e779a9211"
-const BarristerDateGenerated int64 = 1571086745325000000
+const BarristerChecksum string = "2d0e7b734c1013983a76cd82f1ae655e"
+const BarristerDateGenerated int64 = 1572039194918000000
 
 type EventSourceType string
 
@@ -66,6 +66,7 @@ type DockerComponent struct {
 	PullUsername                string        `json:"pullUsername,omitempty"`
 	PullPassword                string        `json:"pullPassword,omitempty"`
 	PullImageOnPut              bool          `json:"pullImageOnPut,omitempty"`
+	PullImageOnStart            bool          `json:"pullImageOnStart,omitempty"`
 }
 
 type VolumeMount struct {
@@ -1505,7 +1506,14 @@ var IdlJsonRaw = `[
                 "type": "bool",
                 "optional": true,
                 "is_array": false,
-                "comment": "If true, image will be pulled after each PutComponent call even if no containers\nfor this component are running. (default=false)\nImages are always pulled for a component when starting a container."
+                "comment": "If true, image will be pulled after each PutComponent call even if no containers\nfor this component are running. (default=false)"
+            },
+            {
+                "name": "pullImageOnStart",
+                "type": "bool",
+                "optional": true,
+                "is_array": false,
+                "comment": "If true, image will be pulled before starting a container. If false, image will\nbe pulled before starting a container only if no image is present locally. (default=false)"
             }
         ],
         "values": null,
@@ -3279,7 +3287,7 @@ var IdlJsonRaw = `[
         "values": null,
         "functions": null,
         "barrister_version": "0.1.6",
-        "date_generated": 1571086745325,
-        "checksum": "664d2fd5d7c3448db18e7f6e779a9211"
+        "date_generated": 1572039194918,
+        "checksum": "2d0e7b734c1013983a76cd82f1ae655e"
     }
 ]`


### PR DESCRIPTION
Both flags are false by default, which means images are only pulled if
they do not exist locally.

If pullimageonput is true, the image will be pulled immediately when the
component is modified.

If pullimageonstart is true, the image will be pulled every time before
starting a container for the component.