### PR TITLE
docker: add support for dns params to project yaml

### DIFF
--- a/docs/gitbook/appendix/project_yaml_ref.md
+++ b/docs/gitbook/appendix/project_yaml_ref.md
@@ -201,6 +201,8 @@ components:
 
 ### Other options
 
+These are all optional properties.
+
 ```yaml
 
 ---
@@ -219,6 +221,9 @@ components:
         type: bind
         # Whether volume is read only. Default = false
         readonly: false
+      # add more volumes using a list
+      - source: /some/other/path
+        target: /otherpath
     # Expose ports from container to host
     # Probably only useful during local development (e.g. for debugger ports)
     # Note that if you statically bind a port here and maxinstances > 1
@@ -230,4 +235,19 @@ components:
     # This is sometimes useful when developing locally and you wish to access 
     # resources from a docker-compose stack that are placed on a non-default network.
     networkname: mynet
+    #
+    # DNS options - this allows you to override the DNS server to use in the container
+    # See docs: https://docs.docker.com/v17.09/engine/userguide/networking/default_network/configure-dns/
+    #
+    # equivalent to docker run --dns
+    dns:
+      - 8.8.8.8
+    # equivalent to docker run --dns-opt 
+    dnsoptions:
+      - "option 1"
+      - "option 2"
+    # equivalent to docker run --dns-search
+    dnssearch:
+      - example.com
+      - example.org
 ```

--- a/idl/maelstrom.idl
+++ b/idl/maelstrom.idl
@@ -331,6 +331,12 @@ struct DockerComponent {
     // If true, image will be pulled before starting a container. If false, image will
     // be pulled before starting a container only if no image is present locally. (default=false)
     pullImageOnStart    bool  [optional]
+
+    // DNS servers, options, and search to set on container
+    // See: https://docs.docker.com/v17.09/engine/userguide/networking/default_network/configure-dns/
+    dns                         []string    [optional]
+    dnsOptions                  []string    [optional]
+    dnsSearch                   []string    [optional]
 }
 
 struct VolumeMount {

--- a/pkg/common/docker.go
+++ b/pkg/common/docker.go
@@ -320,6 +320,17 @@ func toContainerHostConfig(c *v1.Component) (*container.HostConfig, error) {
 		}
 	}
 
+	// DNS
+	if len(c.Docker.Dns) > 0 {
+		hc.DNS = c.Docker.Dns
+	}
+	if len(c.Docker.DnsSearch) > 0 {
+		hc.DNSSearch = c.Docker.DnsSearch
+	}
+	if len(c.Docker.DnsOptions) > 0 {
+		hc.DNSOptions = c.Docker.DnsOptions
+	}
+
 	// Port mappings
 	if len(c.Docker.Ports) > 0 {
 		if hc.PortBindings == nil {

--- a/pkg/maelstrom/project.go
+++ b/pkg/maelstrom/project.go
@@ -158,6 +158,9 @@ type yamlComponent struct {
 	Ports                       []string
 	Volumes                     []v1.VolumeMount
 	NetworkName                 string
+	DNS                         []string
+	DNSOptions                  []string
+	DNSSearch                   []string
 	LogDriver                   string
 	LogDriverOptions            map[string]string
 	EventSources                map[string]v1.EventSource
@@ -259,6 +262,9 @@ func (c yamlComponent) toComponentWithEventSources(name string, projectName stri
 				PullPassword:                c.PullPassword,
 				PullImageOnPut:              c.PullImageOnPut,
 				PullImageOnStart:            c.PullImageOnStart,
+				Dns:                         c.DNS,
+				DnsOptions:                  c.DNSOptions,
+				DnsSearch:                   c.DNSSearch,
 			},
 		},
 		EventSources: eventSources,

--- a/pkg/v1/v1.go
+++ b/pkg/v1/v1.go
@@ -8,8 +8,8 @@ import (
 )
 
 const BarristerVersion string = "0.1.6"
-const BarristerChecksum string = "2d0e7b734c1013983a76cd82f1ae655e"
-const BarristerDateGenerated int64 = 1572039194918000000
+const BarristerChecksum string = "194135bc8fc1ab6f8da7c82522525a3f"
+const BarristerDateGenerated int64 = 1572540328279000000
 
 type EventSourceType string
 
@@ -67,6 +67,9 @@ type DockerComponent struct {
 	PullPassword                string        `json:"pullPassword,omitempty"`
 	PullImageOnPut              bool          `json:"pullImageOnPut,omitempty"`
 	PullImageOnStart            bool          `json:"pullImageOnStart,omitempty"`
+	Dns                         []string      `json:"dns,omitempty"`
+	DnsOptions                  []string      `json:"dnsOptions,omitempty"`
+	DnsSearch                   []string      `json:"dnsSearch,omitempty"`
 }
 
 type VolumeMount struct {
@@ -1514,6 +1517,27 @@ var IdlJsonRaw = `[
                 "optional": true,
                 "is_array": false,
                 "comment": "If true, image will be pulled before starting a container. If false, image will\nbe pulled before starting a container only if no image is present locally. (default=false)"
+            },
+            {
+                "name": "dns",
+                "type": "string",
+                "optional": true,
+                "is_array": true,
+                "comment": "DNS servers, options, and search to set on container\nSee: https://docs.docker.com/v17.09/engine/userguide/networking/default_network/configure-dns/"
+            },
+            {
+                "name": "dnsOptions",
+                "type": "string",
+                "optional": true,
+                "is_array": true,
+                "comment": ""
+            },
+            {
+                "name": "dnsSearch",
+                "type": "string",
+                "optional": true,
+                "is_array": true,
+                "comment": ""
             }
         ],
         "values": null,
@@ -3287,7 +3311,7 @@ var IdlJsonRaw = `[
         "values": null,
         "functions": null,
         "barrister_version": "0.1.6",
-        "date_generated": 1572039194918,
-        "checksum": "2d0e7b734c1013983a76cd82f1ae655e"
+        "date_generated": 1572540328279,
+        "checksum": "194135bc8fc1ab6f8da7c82522525a3f"
     }
 ]`


### PR DESCRIPTION
allows DNS server and search domains to be specified per component.