### PR TITLE
maelstromd: stop/rm container after failed start

### DIFF
--- a/pkg/common/docker.go
+++ b/pkg/common/docker.go
@@ -242,7 +242,7 @@ func StartContainer(dockerClient *docker.Client, c *v1.Component, maelstromUrl s
 
 	err = dockerClient.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})
 	if err != nil {
-		return "", fmt.Errorf("containerStart error for: %s - %v", c.Name, err)
+		return resp.ID, fmt.Errorf("containerStart error for: %s - %v", c.Name, err)
 	}
 	return resp.ID, nil
 }

--- a/pkg/maelstrom/component/container.go
+++ b/pkg/maelstrom/component/container.go
@@ -198,9 +198,12 @@ func (c *Container) run() {
 				}
 			}
 		} else {
-			c.stopContainerQuietly("failed to start")
+			c.stopContainerQuietly("failed to init reverse proxy")
 		}
+	} else {
+		c.stopContainerQuietly("failed to start")
 	}
+
 	if err == nil {
 		log.Info("container: exiting run loop", "containerId", common.StrTruncate(c.containerId, 8))
 	} else {


### PR DESCRIPTION
This prevents zombie "Created" processes for sticking around