### PR TITLE
maelstromd: use sync.Pool for http RoundTrippers. cancel contexts on successful request

### DIFF
--- a/cmd/maelstromd/maelstromd.go
+++ b/cmd/maelstromd/maelstromd.go
@@ -15,6 +15,7 @@ import (
 	docker "github.com/docker/docker/client"
 	"github.com/mgutz/logxi/v1"
 	"net/http"
+	httppprof "net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime"
@@ -222,6 +223,14 @@ func main() {
 
 	privateGateway := maelstrom.NewGateway(resolver, dispatcher, false, outboundIp.String())
 	privateSvrMux := http.NewServeMux()
+	if conf.Pprof {
+		log.Info("maelstromd: binding pprof routes to /_mael/pprof/")
+		privateSvrMux.Handle("/_mael/pprof/heap", httppprof.Handler("heap"))
+		privateSvrMux.Handle("/_mael/pprof/cmdline", http.HandlerFunc(httppprof.Cmdline))
+		privateSvrMux.Handle("/_mael/pprof/profile", http.HandlerFunc(httppprof.Profile))
+		privateSvrMux.Handle("/_mael/pprof/symbol", http.HandlerFunc(httppprof.Symbol))
+		privateSvrMux.Handle("/_mael/pprof/trace", http.HandlerFunc(httppprof.Trace))
+	}
 	privateSvrMux.Handle("/_mael/v1", &v1Server)
 	privateSvrMux.Handle("/_mael/logs", logsHandler)
 	privateSvrMux.Handle("/", privateGateway)

--- a/docs/gitbook/appendix/maelstromd_env_vars.md
+++ b/docs/gitbook/appendix/maelstromd_env_vars.md
@@ -73,7 +73,15 @@ Read more about [Docker image pruning](../production/prune.html)
 
 ## Debugging
 
-| Variable                        | Description                                  | Required? | Default |
-|---------------------------------|----------------------------------------------|-----------|---------|
-| MAEL_LOG_GC_SECONDS             | If set, print GC stats every x seconds       | No        | None    |
-| MAEL_CPU_PROFILE_FILENAME       | If set, write Go profiling info to this file | No        | None    |
+| Variable                        | Description                                   | Required? | Default |
+|---------------------------------|-----------------------------------------------|-----------|---------|
+| MAEL_LOG_GC_SECONDS             | If set, print GC stats every x seconds        | No        | None    |
+| MAEL_CPU_PROFILE_FILENAME       | If set, write Go profiling info to this file  | No        | None    |
+| MAEL_PPROF                      | If true, expose pprof HTTP routes             | No        | false   |
+
+`pprof` routes are bound to the internal gateway port.  For example, to get a heap profile, set `MAEL_PPROF=true` and
+request the `/_mael/pprof/heap` endpoint:
+
+```
+curl -sK -v http://localhost:8374/_mael/pprof/heap > heap.out
+```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,8 +81,12 @@ type Config struct {
 	CronRefreshSeconds int `default:"60"`
 	// If > 0, print gc stats every x seconds
 	LogGcSeconds int
+
 	// If set, log profile data to this filename
 	CpuProfileFilename string
+	// If true, bind go pprof endpoints to private gateway /_mael/pprof/
+	Pprof bool
+
 	// Memory (MiB) to make available to containers (if set to zero, maelstromd will simply act as a relay)
 	TotalMemory int64 `default:"-1"`
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -28,6 +28,7 @@ MAEL_AWS_SPOT_TERMINATE_POLL_SECONDS=55
 
 MAEL_LOG_GC_SECONDS=66
 MAEL_CPU_PROFILE_FILENAME=somefile
+MAEL_PPROF=true
 
 MAEL_DOCKER_PRUNE_MINUTES=123
 MAEL_DOCKER_PRUNE_UNREG_IMAGES=true
@@ -46,6 +47,7 @@ MAEL_NODE_LIVENESS_SECONDS=200
 		CronRefreshSeconds:          50,
 		LogGcSeconds:                66,
 		CpuProfileFilename:          "somefile",
+		Pprof:                       true,
 		TotalMemory:                 -200,
 		TerminateCommand:            "term cmd",
 		ShutdownPauseSeconds:        3,

--- a/pkg/maelstrom/component/dispatcher.go
+++ b/pkg/maelstrom/component/dispatcher.go
@@ -116,7 +116,7 @@ func (d *Dispatcher) Route(rw http.ResponseWriter, req *http.Request, comp *v1.C
 		}
 	}
 	deadline := componentReqDeadline(deadlineNano, comp)
-	ctx, _ := context.WithDeadline(context.Background(), deadline)
+	ctx, ctxCancel := context.WithDeadline(context.Background(), deadline)
 	if req.Header.Get("MAELSTROM-DEADLINE-NANO") == "" {
 		req.Header.Set("MAELSTROM-DEADLINE-NANO", strconv.FormatInt(deadline.UnixNano(), 10))
 	}
@@ -137,6 +137,7 @@ func (d *Dispatcher) Route(rw http.ResponseWriter, req *http.Request, comp *v1.C
 	// Block on result, or timeout
 	select {
 	case <-compReq.Done:
+		ctxCancel()
 		return
 	case <-ctx.Done():
 		msg := "gateway: Timeout proxying component: " + comp.Name

--- a/pkg/maelstrom/component/pool.go
+++ b/pkg/maelstrom/component/pool.go
@@ -1,0 +1,28 @@
+package component
+
+import "sync"
+
+func NewProxyBufferPool() *ProxyBufferPool {
+	pool := &sync.Pool{
+		New: func() interface{} {
+			return make([]byte, 32*1024)
+		},
+	}
+	return &ProxyBufferPool{pool: pool}
+}
+
+type ProxyBufferPool struct {
+	pool *sync.Pool
+}
+
+func (p *ProxyBufferPool) Get() []byte {
+	b, ok := p.pool.Get().([]byte)
+	if !ok {
+		panic("pool didn't not return a []byte")
+	}
+	return b
+}
+
+func (p *ProxyBufferPool) Put(b []byte) {
+	p.pool.Put(b)
+}


### PR DESCRIPTION
Also: add optional MAEL_PPROF env var. If true, bind pprof routes so profiling output
can be captured at runtime.