### PR TITLE
maelstromd: lock on resolveAndBroadcastNodeStatus to avoid insert races

### DIFF
--- a/pkg/maelstrom/node_svc.go
+++ b/pkg/maelstrom/node_svc.go
@@ -829,6 +829,9 @@ func (n *NodeServiceImpl) logStatus(ctx context.Context) error {
 }
 
 func (n *NodeServiceImpl) resolveAndBroadcastNodeStatus(ctx context.Context) (v1.NodeStatus, error) {
+	n.loadStatusLock.Lock()
+	defer n.loadStatusLock.Unlock()
+
 	status, err := n.resolveNodeStatus(ctx)
 	if err != nil {
 		return status, err

--- a/pkg/maelstrom/sql_db.go
+++ b/pkg/maelstrom/sql_db.go
@@ -442,8 +442,11 @@ func (d *SqlDb) PutNodeStatus(status v1.NodeStatus) error {
 		return fmt.Errorf("PutNodeStatus RowsAffected failed for nodeId: %s err: %v", status.NodeId, err)
 	}
 	if rows != 1 {
+		conflictSql := strings.Replace(d.onConflictSql, "<TARGET>", "(nodeId)", 1)
 		q := squirrel.Insert("nodestatus").
-			Columns("nodeId", "observedAt", "json").Values(status.NodeId, status.ObservedAt, jsonVal)
+			Columns("nodeId", "observedAt", "json").
+			Values(status.NodeId, status.ObservedAt, jsonVal).
+			Suffix(conflictSql+"observedAt=?", status.ObservedAt)
 		_, err := q.RunWith(d.db).Exec()
 		if err != nil {
 			return fmt.Errorf("PutNodeStatus insert failed for nodeId: %s err: %v", status.NodeId, err)


### PR DESCRIPTION
Avoids errors like this when a new node comes online and multiple containers start concurrently:

```Dec  6 17:21:09 ip-172-32-1-93 maelstromd: {"_t":"2019-12-06T17:21:09-0800", "_p":"4156", "_l":"ERR", "_n":"~", "_m":"nodesvc: OnContainersChanged error", "err":"PutNodeStatus insert failed for nodeId: ZZN4:FQLX:4FC7:C4TW:ZPUB:NMTC:ALCU:QP3Q:IGEU:MAPH:U5RX:KCCU err: Error 1062: Duplicate entry 'ZZN4:FQLX:4FC7:C4TW:ZPUB:NMTC:ALCU:QP3Q:IGEU:MAPH:U5RX:KCCU' for key 'PRIMARY'", ```