### PR TITLE
maelstromd: restart containers on change

### DIFF
--- a/pkg/converge/converger.go
+++ b/pkg/converge/converger.go
@@ -167,7 +167,8 @@ func (c *Converger) OnDockerEvent(event *common.DockerEvent) {
 	if event.ContainerExited != nil && event.ContainerExited.ContainerId != "" {
 		c.stopAndRemoveContainer(0, event.ContainerExited.ContainerId, "container exited")
 		run = true
-	} else if event.ImageUpdated != nil && c.GetTarget().Component.Docker.Image == event.ImageUpdated.ImageName {
+	} else if event.ImageUpdated != nil && common.NormalizeImageName(c.GetTarget().Component.Docker.Image) ==
+		common.NormalizeImageName(event.ImageUpdated.ImageName) {
 		c.markContainersForTermination(reasonImageUpdated)
 		run = true
 	}

--- a/pkg/converge/registry.go
+++ b/pkg/converge/registry.go
@@ -83,10 +83,10 @@ func (r *Registry) Shutdown() {
 
 func (r *Registry) OnDockerEvent(msg common.DockerEvent) {
 	r.lock.Lock()
-	comps := r.byCompName
+	convergers := r.byCompName
 	r.lock.Unlock()
 
-	for _, c := range comps {
+	for _, c := range convergers {
 		c.OnDockerEvent(&msg)
 	}
 }


### PR DESCRIPTION
We weren't sanitizing the image name so changes to "latest" were being ignored.