### PR TITLE
autoscale: block when telling nodes to start/stop containers

### DIFF
--- a/idl/maelstrom.idl
+++ b/idl/maelstrom.idl
@@ -861,6 +861,10 @@ struct StartStopComponentsInput {
     // If true, targetStatus will be populated after performing changes
     // Optional. default=false
     returnStatus        bool     [optional]
+
+    // If true, block until target applies targetCounts
+    // Optional. default=false
+    block               bool     [optional]
 }
 
 struct StartStopComponentsOutput {

--- a/pkg/maelstrom/fixture_test.go
+++ b/pkg/maelstrom/fixture_test.go
@@ -499,7 +499,7 @@ func (f *Fixture) WhenStopRequestReceived() *Fixture {
 			Component: &f.component,
 			Count:     0,
 		},
-	})
+	}, true)
 	return f
 }
 

--- a/pkg/maelstrom/placement.go
+++ b/pkg/maelstrom/placement.go
@@ -107,6 +107,12 @@ func (p *PlacementOption) ramForComponent(componentName string) int64 {
 }
 
 func (p *PlacementOption) scaleDownCount() int {
+	_, scaleDown := p.scaleUpDownCounts()
+	return scaleDown
+}
+
+func (p *PlacementOption) scaleUpDownCounts() (int, int) {
+	scaleUp := 0
 	scaleDown := 0
 	byComp := map[string]int{}
 	for _, ci := range p.TargetNode.RunningComponents {
@@ -115,9 +121,11 @@ func (p *PlacementOption) scaleDownCount() int {
 	for _, tc := range p.Input.TargetCounts {
 		if tc.TargetCount < int64(byComp[tc.ComponentName]) {
 			scaleDown++
+		} else if tc.TargetCount > int64(byComp[tc.ComponentName]) {
+			scaleUp++
 		}
 	}
-	return scaleDown
+	return scaleUp, scaleDown
 }
 
 type PlacementOptionByNode []*PlacementOption

--- a/pkg/maelstrom/scale.go
+++ b/pkg/maelstrom/scale.go
@@ -71,6 +71,23 @@ func CalcAutoscalePlacement(nodes []v1.NodeStatus, componentsByName map[string]v
 	return computeScaleStartStopInputs(nodes, deltas)
 }
 
+func groupOptionsByType(options []*PlacementOption) [][]*PlacementOption {
+	startOnly := make([]*PlacementOption, 0)
+	startStop := make([]*PlacementOption, 0)
+	stopOnly := make([]*PlacementOption, 0)
+	for _, opt := range options {
+		start, stop := opt.scaleUpDownCounts()
+		if start > 0 && stop > 0 {
+			startStop = append(startStop, opt)
+		} else if start > 0 {
+			startOnly = append(startOnly, opt)
+		} else {
+			stopOnly = append(stopOnly, opt)
+		}
+	}
+	return [][]*PlacementOption{startOnly, startStop, stopOnly}
+}
+
 func componentsByName(comps []v1.Component) map[string]v1.Component {
 	byName := map[string]v1.Component{}
 	for _, c := range comps {

--- a/pkg/maelstrom/scale_test.go
+++ b/pkg/maelstrom/scale_test.go
@@ -157,11 +157,11 @@ func testScaleUpPlacesOnEmptyNode(t *testing.T) {
 
 func TestPlaceHighRAMComponent(t *testing.T) {
 	for i := 0; i < 300; i++ {
-		testFoo(t)
+		testPlaceHighRAM(t)
 	}
 }
 
-func testFoo(t *testing.T) {
+func testPlaceHighRAM(t *testing.T) {
 	// - test: 3 nodes, 2 w/o enough ram to run component, 1 with enough, but running other components.
 	//   should rebalance components from n3 to n1/2 and start big component on n3.
 

--- a/pkg/v1/v1.go
+++ b/pkg/v1/v1.go
@@ -8,8 +8,16 @@ import (
 )
 
 const BarristerVersion string = "0.1.6"
-const BarristerChecksum string = "9aa3db77f6530d7652898e94f5a1e236"
-const BarristerDateGenerated int64 = 1577718957314000000
+const BarristerChecksum string = "0b30299aa362323e1b112a9dda3313a4"
+const BarristerDateGenerated int64 = 1578665504812000000
+
+type StartParallelism string
+
+const (
+	StartParallelismParallel    StartParallelism = "parallel"
+	StartParallelismSeries                       = "series"
+	StartParallelismSeriesfirst                  = "seriesfirst"
+)
 
 type RestartOrder string
 
@@ -25,14 +33,6 @@ const (
 	EventSourceTypeCron                        = "cron"
 	EventSourceTypeSqs                         = "sqs"
 	EventSourceTypeAwsstepfunc                 = "awsstepfunc"
-)
-
-type StartParallelism string
-
-const (
-	StartParallelismParallel    StartParallelism = "parallel"
-	StartParallelismSeries                       = "series"
-	StartParallelismSeriesfirst                  = "seriesfirst"
 )
 
 type Project struct {
@@ -372,6 +372,7 @@ type StartStopComponentsInput struct {
 	TargetVersion int64             `json:"targetVersion"`
 	TargetCounts  []ComponentTarget `json:"targetCounts"`
 	ReturnStatus  bool              `json:"returnStatus,omitempty"`
+	Block         bool              `json:"block,omitempty"`
 }
 
 type StartStopComponentsOutput struct {
@@ -3358,6 +3359,13 @@ var IdlJsonRaw = `[
                 "optional": true,
                 "is_array": false,
                 "comment": "If true, targetStatus will be populated after performing changes\nOptional. default=false"
+            },
+            {
+                "name": "block",
+                "type": "bool",
+                "optional": true,
+                "is_array": false,
+                "comment": "If true, block until target applies targetCounts\nOptional. default=false"
             }
         ],
         "values": null,
@@ -3663,7 +3671,7 @@ var IdlJsonRaw = `[
         "values": null,
         "functions": null,
         "barrister_version": "0.1.6",
-        "date_generated": 1577718957314,
-        "checksum": "9aa3db77f6530d7652898e94f5a1e236"
+        "date_generated": 1578665504812,
+        "checksum": "0b30299aa362323e1b112a9dda3313a4"
     }
 ]`


### PR DESCRIPTION
During rebalancing we were stopping and starting containers
concurrently, which caused request routing to pause until the
new container was ready.

Now we group the PlacementOption lists into 3 groups:
  - only starting containers
  - starting and stopping containers
  - only stopping containers

We then apply each group in order, blocking until all nodes for
that group have converged.

This will cause a rebalance to start new containers on the empty hosts
first, then stop containers on the other hosts.