### PR TITLE
maelstromd: add status field to ComponentInfo, block during provision call

### DIFF
--- a/cmd/maelctl/maelctl.go
+++ b/cmd/maelctl/maelctl.go
@@ -99,7 +99,7 @@ func clusterPs(args docopt.Opts, nodeSvc v1.NodeService) {
 		if len(node.RunningComponents) > 0 {
 			if first {
 				first = false
-				fmt.Printf("%-30s  %-5s  %-14s  %-7s  %-15s  %-11s  %-6s  %-5s\n", "Component", "Ver", "Node ID", "Max RAM", "Last Request", "# Requests", "Concur", "Max Concur")
+				fmt.Printf("%-30s  %-5s  %-8s  %-14s  %-7s  %-15s  %-11s  %-8s\n", "Component", "Ver", "Status", "Node ID", "Max RAM", "Last Request", "# Requests", "Concur %")
 				fmt.Printf("-----------------------------------------------------------------------------------------------------------------\n")
 			}
 			for _, rc := range node.RunningComponents {
@@ -115,9 +115,14 @@ func clusterPs(args docopt.Opts, nodeSvc v1.NodeService) {
 					}
 					avgConcur = sumConcur / float64(len(rc.Activity))
 				}
-				fmt.Printf("%-30s  %-5d  %-14s  %-7d  %-15s  %-11d  %-6.2f  %-5d\n", trunc(rc.ComponentName, 30),
-					rc.ComponentVersion, trunc(node.NodeId, 14), rc.MemoryReservedMiB, lastReqAt, rc.TotalRequests,
-					avgConcur, rc.MaxConcurrency)
+				maxConcur := rc.MaxConcurrency
+				if maxConcur <= 0 {
+					maxConcur = 1
+				}
+				concurPct := 100.0 * (avgConcur / float64(maxConcur))
+				fmt.Printf("%-30s  %-5d  %-8s  %-14s  %-7d  %-15s  %-11d  %-8.2f\n", trunc(rc.ComponentName, 30),
+					rc.ComponentVersion, rc.Status, trunc(node.NodeId, 14), rc.MemoryReservedMiB, lastReqAt,
+					rc.TotalRequests, concurPct)
 			}
 		}
 	}

--- a/idl/maelstrom.idl
+++ b/idl/maelstrom.idl
@@ -561,9 +561,16 @@ struct NodeStatus {
     runningComponents  []ComponentInfo
 }
 
+enum ComponentStatus {
+    active
+    starting
+    stopping
+}
+
 struct ComponentInfo {
     componentName      string
     componentVersion   int
+    status             ComponentStatus
     maxConcurrency     int
     memoryReservedMiB  int
     startTime          int

--- a/pkg/converge/container.go
+++ b/pkg/converge/container.go
@@ -142,7 +142,7 @@ func (c *Container) setStatus(newStatus v1.ComponentStatus) {
 	c.statLock.Lock()
 	if log.IsDebug() {
 		log.Debug("container: changing status", "from", c.status, "to", newStatus,
-			"containerId", c.containerId)
+			"containerId", common.StrTruncate(c.containerId, 8))
 	}
 	c.status = newStatus
 	c.statLock.Unlock()

--- a/pkg/converge/container.go
+++ b/pkg/converge/container.go
@@ -21,7 +21,6 @@ import (
 )
 
 type maelContainerId uint64
-type maelContainerStatus int
 
 func NewContainer(dockerClient *docker.Client, component *v1.Component, maelstromUrl string,
 	router *router.Router, id maelContainerId, bufferPool httputil.BufferPool, parentCtx context.Context) *Container {
@@ -36,6 +35,7 @@ func NewContainer(dockerClient *docker.Client, component *v1.Component, maelstro
 
 	c := &Container{
 		id:                     id,
+		status:                 v1.ComponentStatusStarting,
 		dockerClient:           dockerClient,
 		router:                 router,
 		runWg:                  &sync.WaitGroup{},
@@ -59,7 +59,7 @@ func NewContainer(dockerClient *docker.Client, component *v1.Component, maelstro
 
 type Container struct {
 	id     maelContainerId
-	status maelContainerStatus
+	status v1.ComponentStatus
 
 	// marker field - if non-empty, container should be terminated by converger
 	terminateReason string
@@ -108,6 +108,7 @@ func (c *Container) ComponentInfo() v1.ComponentInfo {
 	info := v1.ComponentInfo{
 		ComponentName:     c.component.Name,
 		ComponentVersion:  c.component.Version,
+		Status:            c.status,
 		MaxConcurrency:    c.component.MaxConcurrency,
 		MemoryReservedMiB: c.component.Docker.ReserveMemoryMiB,
 		StartTime:         common.TimeToMillis(c.startTime),
@@ -119,19 +120,11 @@ func (c *Container) ComponentInfo() v1.ComponentInfo {
 	return info
 }
 
-func (c *Container) CancelAndStop(reason string) {
+func (c *Container) JoinAndStop(reason string) {
 	log.Info("container: shutting down", "reason", reason, "containerId", common.StrTruncate(c.containerId, 8))
 
-	// cancel context - this will cause rev proxies and run loop to exit
-	// note that rev proxies may not fully drain reqCh - so this should only
-	// be called when doing a partial scale down
-	c.cancel()
+	c.setStatus(v1.ComponentStatusStopping)
 
-	// call join and stop so that we remove container
-	c.JoinAndStop(reason)
-}
-
-func (c *Container) JoinAndStop(reason string) {
 	// cancel context - this will terminate run loop
 	c.cancel()
 
@@ -143,6 +136,16 @@ func (c *Container) JoinAndStop(reason string) {
 
 	// remove container
 	c.stopContainerQuietly(reason)
+}
+
+func (c *Container) setStatus(newStatus v1.ComponentStatus) {
+	c.statLock.Lock()
+	if log.IsDebug() {
+		log.Debug("container: changing status", "from", c.status, "to", newStatus,
+			"containerId", c.containerId)
+	}
+	c.status = newStatus
+	c.statLock.Unlock()
 }
 
 func (c *Container) startAndHealthCheck(ctx context.Context) error {
@@ -159,7 +162,9 @@ func (c *Container) startAndHealthCheck(ctx context.Context) error {
 		}
 	}
 
-	if err != nil {
+	if err == nil {
+		c.setStatus(v1.ComponentStatusActive)
+	} else {
 		c.stopContainerQuietly(stopReason)
 	}
 	return err
@@ -265,7 +270,7 @@ func (c *Container) runHealthCheck() {
 			log.Error("container: health check failed. stopping container",
 				"containerId", common.StrTruncate(c.containerId, 8),
 				"component", c.component.Name, "failures", c.healthCheckFailures)
-			go c.CancelAndStop("health check failed")
+			go c.JoinAndStop("health check failed")
 			c.healthCheckFailures = 0
 		} else {
 			log.Warn("container: health check failed", "failures", c.healthCheckFailures,
@@ -334,7 +339,8 @@ func (c *Container) initReverseProxy(ctx context.Context) error {
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.BufferPool = c.bufferPool
 	proxy.Transport = &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:               http.ProxyFromEnvironment,
+		MaxIdleConnsPerHost: maxConcurrency(c.component),
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -117,7 +117,7 @@ func (r *Router) SetRemoteHandlerCounts(urlToHandlerCount map[string]int) {
 		u, err := url.Parse(targetUrl)
 		if err == nil {
 			for targetCount > len(cancelFuncs) {
-				cancelFunc = r.startRemoteHandler(u)
+				cancelFunc = r.startRemoteHandler(u, targetCount)
 				cancelFuncs = append(cancelFuncs, cancelFunc)
 				r.remoteHandlersByUrl[targetUrl] = cancelFuncs
 				change = true
@@ -150,11 +150,12 @@ func (r *Router) SetRemoteHandlerCounts(urlToHandlerCount map[string]int) {
 	}
 }
 
-func (r *Router) startRemoteHandler(targetUrl *url.URL) context.CancelFunc {
+func (r *Router) startRemoteHandler(targetUrl *url.URL, targetCount int) context.CancelFunc {
 	proxy := httputil.NewSingleHostReverseProxy(targetUrl)
 	proxy.BufferPool = r.bufferPool
 	proxy.Transport = &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:               http.ProxyFromEnvironment,
+		MaxIdleConnsPerHost: targetCount,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,

--- a/pkg/v1/event_source.go
+++ b/pkg/v1/event_source.go
@@ -15,6 +15,7 @@ func StrToEventSourceType(esType string) (EventSourceType, error) {
 	}
 	return "", fmt.Errorf("invalid EventSourceType: %s", esType)
 }
+
 func GetEventSourceType(e EventSource) EventSourceType {
 	if e.Http != nil {
 		return EventSourceTypeHttp

--- a/pkg/v1/v1.go
+++ b/pkg/v1/v1.go
@@ -8,8 +8,17 @@ import (
 )
 
 const BarristerVersion string = "0.1.6"
-const BarristerChecksum string = "0b30299aa362323e1b112a9dda3313a4"
-const BarristerDateGenerated int64 = 1578665504812000000
+const BarristerChecksum string = "f2f4945279a28f7225c85591c24b6034"
+const BarristerDateGenerated int64 = 1578752457622000000
+
+type EventSourceType string
+
+const (
+	EventSourceTypeHttp        EventSourceType = "http"
+	EventSourceTypeCron                        = "cron"
+	EventSourceTypeSqs                         = "sqs"
+	EventSourceTypeAwsstepfunc                 = "awsstepfunc"
+)
 
 type StartParallelism string
 
@@ -26,13 +35,12 @@ const (
 	RestartOrderStopstart              = "stopstart"
 )
 
-type EventSourceType string
+type ComponentStatus string
 
 const (
-	EventSourceTypeHttp        EventSourceType = "http"
-	EventSourceTypeCron                        = "cron"
-	EventSourceTypeSqs                         = "sqs"
-	EventSourceTypeAwsstepfunc                 = "awsstepfunc"
+	ComponentStatusActive   ComponentStatus = "active"
+	ComponentStatusStarting                 = "starting"
+	ComponentStatusStopping                 = "stopping"
 )
 
 type Project struct {
@@ -168,6 +176,7 @@ type NodeStatus struct {
 type ComponentInfo struct {
 	ComponentName     string              `json:"componentName"`
 	ComponentVersion  int64               `json:"componentVersion"`
+	Status            ComponentStatus     `json:"status"`
 	MaxConcurrency    int64               `json:"maxConcurrency"`
 	MemoryReservedMiB int64               `json:"memoryReservedMiB"`
 	StartTime         int64               `json:"startTime"`
@@ -2192,6 +2201,32 @@ var IdlJsonRaw = `[
         "checksum": ""
     },
     {
+        "type": "enum",
+        "name": "ComponentStatus",
+        "comment": "",
+        "value": "",
+        "extends": "",
+        "fields": null,
+        "values": [
+            {
+                "value": "active",
+                "comment": ""
+            },
+            {
+                "value": "starting",
+                "comment": ""
+            },
+            {
+                "value": "stopping",
+                "comment": ""
+            }
+        ],
+        "functions": null,
+        "barrister_version": "",
+        "date_generated": 0,
+        "checksum": ""
+    },
+    {
         "type": "struct",
         "name": "ComponentInfo",
         "comment": "",
@@ -2208,6 +2243,13 @@ var IdlJsonRaw = `[
             {
                 "name": "componentVersion",
                 "type": "int",
+                "optional": false,
+                "is_array": false,
+                "comment": ""
+            },
+            {
+                "name": "status",
+                "type": "ComponentStatus",
                 "optional": false,
                 "is_array": false,
                 "comment": ""
@@ -3671,7 +3713,7 @@ var IdlJsonRaw = `[
         "values": null,
         "functions": null,
         "barrister_version": "0.1.6",
-        "date_generated": 1578665504812,
-        "checksum": "0b30299aa362323e1b112a9dda3313a4"
+        "date_generated": 1578752457622,
+        "checksum": "f2f4945279a28f7225c85591c24b6034"
     }
 ]`


### PR DESCRIPTION
The goal of this commit is to prevent multiple nodes from concurrently starting the same component and to propagate routing changes to peers more rapidly. 

Nodes will communicate changes to container state as they start and stop instances, as opposed to only sending state changes after an operation completes.