### PR TITLE
stepfunc: plumb error and cause fields to SendTaskFailure

### DIFF
--- a/docs/gitbook/event_sources/aws_stepfunc.md
+++ b/docs/gitbook/event_sources/aws_stepfunc.md
@@ -6,6 +6,22 @@ component is activated and the task input is sent to the component via HTTP POST
 POST body. If the component responds with a 200 status code, `SendTaskSuccess` is called using the response body as
 the `output` field. If a non-200 response is returned, or if the request times out, `SendTaskFailure` is called.
 
+## Errors
+
+If a non-200 response is returned, `SendTaskFailure` is called. You may optionally
+set response HTTP headers for the "cause" and "error" to be sent back to AWS. These values will be
+displayed in the step function UI.
+
+See the [SendTaskFailure docs](https://docs.aws.amazon.com/step-functions/latest/apireference/API_SendTaskFailure.html) for more info on these fields.
+
+`taskToken` is automatically set on the `SendTaskFailure` call and cannot be
+overridden.
+
+| HTTP Header      | SendTaskFailure Field    | Max Length                
+|------------------|--------------------------|----------------------
+| step-func-error  | error                    | 256
+| step-func-cause  | cause                    | 32768
+
 ## Activity creation
 
 `maelstromd` will call `CreateActivity` to resolve the ARN associated with the activity name, but you must 

--- a/pkg/evsource/aws/stepfunc/stepfunc.go
+++ b/pkg/evsource/aws/stepfunc/stepfunc.go
@@ -147,8 +147,12 @@ func (s *StepFuncPoller) worker(wg *sync.WaitGroup, reqCh chan *sfn.GetActivityT
 					log.Error("evstepfunc: SendTaskSuccess", "err", err, "arn", s.arn)
 				}
 			} else {
+				errStr := common.StrTruncate(rw.Header().Get("step-func-error"), 256)
+				causeStr := common.StrTruncate(rw.Header().Get("step-func-cause"), 32768)
 				_, err = s.sfnClient.SendTaskFailure(&sfn.SendTaskFailureInput{
 					TaskToken: out.TaskToken,
+					Error:     aws.String(errStr),
+					Cause:     aws.String(causeStr),
 				})
 				if err != nil {
 					log.Error("evstepfunc: SendTaskFailure", "err", err, "arn", s.arn)


### PR DESCRIPTION
If "step-func-error" or "step-func-cause" HTTP headers are set, they'll
be mapped to fields on the SendTaskFailure call so they can be visible
in the AWS UI.