### PR TITLE
router: add longer time bias for local routing

### DIFF
--- a/pkg/revproxy/revproxy.go
+++ b/pkg/revproxy/revproxy.go
@@ -47,8 +47,10 @@ func handleReq(req *Request, myNodeId string, componentName string, proxy *httpu
 		relayPath := req.Req.Header.Get("MAELSTROM-RELAY-PATH")
 		if relayPath == "" {
 			relayPath = myNodeId
-		} else {
+		} else if len(relayPath) < 1024 {
 			relayPath = relayPath + "|" + myNodeId
+		} else {
+			log.Warn("revproxy: relay path too long to append to", "component", componentName)
 		}
 		req.Req.Header.Set("MAELSTROM-COMPONENT", componentName)
 		req.Req.Header.Set("MAELSTROM-RELAY-PATH", relayPath)


### PR DESCRIPTION
Also avoid appending to relayPath if header is already 1KB

This is an attempt to avoid HTTP 413 errors we've seen, which we
think result from the request bouncing around the cluster.