### PR TITLE
maelstromd: add maxinstancespernode property

### DIFF
--- a/docs/gitbook/appendix/project_yaml_ref.md
+++ b/docs/gitbook/appendix/project_yaml_ref.md
@@ -69,9 +69,12 @@ components:
     # Minimum instances of this component to run at any time
     # Optional. Default = 0
     mininstances: 1
-    # Maximum instances of this component to run at any time
+    # Maximum instances of this component to run at any time across all nodes
     # Optional. Default is unlimited.
     maxinstances: 30
+    # Maximum instances of this component to run on a single node
+    # Optional. Default is unlimited.
+    maxinstancespernode: 3
     # Maximum seconds a request may take to complete, including wait time if 
     # max concurrency is reached. Optional. Default = 300
     maxdurationseconds: 60

--- a/idl/maelstrom.idl
+++ b/idl/maelstrom.idl
@@ -231,8 +231,11 @@ struct Component {
     // Minimum instances of this component to run (default=0)
     minInstances int      [optional]
 
-    // Maximum instances of this component to run (default=0, no upper limit)
+    // Maximum instances of this component to run across the entire cluster (default=0, no upper limit)
     maxInstances int      [optional]
+
+    // Maximum instances of this component to run on a single node (default=0, no upper limit)
+    maxInstancesPerNode        int     [optional]
 
     // Maximum concurrent requests to proxy to a single instance of this component
     maxConcurrency      int

--- a/pkg/maelstrom/mael_svc_test.go
+++ b/pkg/maelstrom/mael_svc_test.go
@@ -64,6 +64,7 @@ func TestComponentCRUD(t *testing.T) {
 				MaxDurationSeconds:      input.Component.MaxDurationSeconds,
 				MinInstances:            input.Component.MinInstances,
 				MaxInstances:            input.Component.MaxInstances,
+				MaxInstancesPerNode:     input.Component.MaxInstancesPerNode,
 				ScaleDownConcurrencyPct: input.Component.ScaleDownConcurrencyPct,
 				ScaleUpConcurrencyPct:   input.Component.ScaleUpConcurrencyPct,
 				StartParallelism:        input.Component.StartParallelism,

--- a/pkg/maelstrom/project.go
+++ b/pkg/maelstrom/project.go
@@ -146,6 +146,7 @@ type yamlComponent struct {
 	Environment                 []string
 	MinInstances                int64
 	MaxInstances                int64
+	MaxInstancesPerNode         int64
 	MaxConcurrency              int64
 	ScaleDownConcurrencyPct     float64
 	ScaleUpConcurrencyPct       float64
@@ -245,6 +246,7 @@ func (c yamlComponent) toComponentWithEventSources(name string, projectName stri
 			Environment:             environment,
 			MinInstances:            c.MinInstances,
 			MaxInstances:            c.MaxInstances,
+			MaxInstancesPerNode:     c.MaxInstancesPerNode,
 			MaxConcurrency:          c.MaxConcurrency,
 			MaxDurationSeconds:      c.MaxDurationSeconds,
 			ScaleDownConcurrencyPct: c.ScaleDownConcurrencyPct,

--- a/pkg/maelstrom/project_test.go
+++ b/pkg/maelstrom/project_test.go
@@ -109,6 +109,7 @@ components:
       - B=gizmoB
     mininstances: 1
     maxinstances: 5
+    maxinstancespernode: 2
     maxconcurrency: 3
     maxdurationseconds: 30
     restartorder: startstop
@@ -274,10 +275,11 @@ components:
 						Command:          []string{"python", "gizmo.py"},
 						LogDriverOptions: []v1.NameValue{},
 					},
-					MinInstances:       1,
-					MaxInstances:       5,
-					MaxConcurrency:     3,
-					MaxDurationSeconds: 30,
+					MinInstances:        1,
+					MaxInstances:        5,
+					MaxInstancesPerNode: 2,
+					MaxConcurrency:      3,
+					MaxDurationSeconds:  30,
 				},
 				EventSources: []v1.EventSourceWithStatus{},
 			},

--- a/pkg/v1/v1.go
+++ b/pkg/v1/v1.go
@@ -8,8 +8,8 @@ import (
 )
 
 const BarristerVersion string = "0.1.6"
-const BarristerChecksum string = "f2f4945279a28f7225c85591c24b6034"
-const BarristerDateGenerated int64 = 1578752457622000000
+const BarristerChecksum string = "22ad1a00d9a67ee90aefa957418e3664"
+const BarristerDateGenerated int64 = 1580221399813000000
 
 type EventSourceType string
 
@@ -59,6 +59,7 @@ type Component struct {
 	Environment             []NameValue      `json:"environment"`
 	MinInstances            int64            `json:"minInstances,omitempty"`
 	MaxInstances            int64            `json:"maxInstances,omitempty"`
+	MaxInstancesPerNode     int64            `json:"maxInstancesPerNode,omitempty"`
 	MaxConcurrency          int64            `json:"maxConcurrency"`
 	ScaleUpConcurrencyPct   float64          `json:"scaleUpConcurrencyPct,omitempty"`
 	ScaleDownConcurrencyPct float64          `json:"scaleDownConcurrencyPct,omitempty"`
@@ -1399,7 +1400,14 @@ var IdlJsonRaw = `[
                 "type": "int",
                 "optional": true,
                 "is_array": false,
-                "comment": "Maximum instances of this component to run (default=0, no upper limit)"
+                "comment": "Maximum instances of this component to run across the entire cluster (default=0, no upper limit)"
+            },
+            {
+                "name": "maxInstancesPerNode",
+                "type": "int",
+                "optional": true,
+                "is_array": false,
+                "comment": "Maximum instances of this component to run on a single node (default=0, no upper limit)"
             },
             {
                 "name": "maxConcurrency",
@@ -3713,7 +3721,7 @@ var IdlJsonRaw = `[
         "values": null,
         "functions": null,
         "barrister_version": "0.1.6",
-        "date_generated": 1578752457622,
-        "checksum": "f2f4945279a28f7225c85591c24b6034"
+        "date_generated": 1580221399813,
+        "checksum": "22ad1a00d9a67ee90aefa957418e3664"
     }
 ]`


### PR DESCRIPTION
This limits the number of instances of a component to place on a single node.
The property is optional (default=unlimited per node)