### PR TITLE
maelstromd: add softconcurrencylimit to component

### DIFF
--- a/docs/gitbook/appendix/project_yaml_ref.md
+++ b/docs/gitbook/appendix/project_yaml_ref.md
@@ -66,6 +66,11 @@ components:
     # Maximum concurrent requests to send to a single container
     # Optional. Default = 1
     maxconcurrency: 5
+    # If true, maxconcurrency will be used influence autoscaling, but will not
+    # be used to queue requests over the limit. Requests to this component will
+    # be load balanced, but will passed through with no limits.
+    # Optional. Default = false
+    softconcurrencylimit: true
     # Minimum instances of this component to run at any time
     # Optional. Default = 0
     mininstances: 1

--- a/go.mod
+++ b/go.mod
@@ -36,3 +36,5 @@ require (
 	golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b
 	golang.org/x/oauth2 v0.0.0-20190523182746-aaccbc9213b0
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,7 @@ github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
 github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/idl/maelstrom.idl
+++ b/idl/maelstrom.idl
@@ -240,6 +240,10 @@ struct Component {
     // Maximum concurrent requests to proxy to a single instance of this component
     maxConcurrency      int
 
+    // If true, maxConcurrency will be used to autoscale the component, but will not
+    // cause requests exceeding the limit to queue (default=false)
+    softConcurrencyLimit       bool    [optional]
+
     // If the % of maxConcurrency of all instances of this component exceeds this value,
     // more instances of the component will be started (respecting maxInstances if > 0).
     // Value should be 0..1 (e.g. .5 = 50%). (default=0.75)

--- a/pkg/maelstrom/mael_svc_test.go
+++ b/pkg/maelstrom/mael_svc_test.go
@@ -2,15 +2,16 @@ package maelstrom
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/coopernurse/barrister-go"
 	"github.com/coopernurse/maelstrom/pkg/db"
 	"github.com/coopernurse/maelstrom/pkg/test"
-	"github.com/coopernurse/maelstrom/pkg/v1"
-	"github.com/google/gofuzz"
+	v1 "github.com/coopernurse/maelstrom/pkg/v1"
+	fuzz "github.com/google/gofuzz"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 func createV1() (*MaelServiceImpl, *db.SqlDb) {
@@ -62,6 +63,7 @@ func TestComponentCRUD(t *testing.T) {
 				Environment:             input.Component.Environment,
 				MaxConcurrency:          input.Component.MaxConcurrency,
 				MaxDurationSeconds:      input.Component.MaxDurationSeconds,
+				SoftConcurrencyLimit:    input.Component.SoftConcurrencyLimit,
 				MinInstances:            input.Component.MinInstances,
 				MaxInstances:            input.Component.MaxInstances,
 				MaxInstancesPerNode:     input.Component.MaxInstancesPerNode,

--- a/pkg/maelstrom/placement_test.go
+++ b/pkg/maelstrom/placement_test.go
@@ -2,15 +2,16 @@ package maelstrom
 
 import (
 	"fmt"
-	"github.com/coopernurse/maelstrom/pkg/common"
-	v1 "github.com/coopernurse/maelstrom/pkg/v1"
-	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"reflect"
 	"strconv"
 	"testing"
 	"testing/quick"
 	"time"
+
+	"github.com/coopernurse/maelstrom/pkg/common"
+	v1 "github.com/coopernurse/maelstrom/pkg/v1"
+	"github.com/stretchr/testify/assert"
 )
 
 var defaultRand = rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/pkg/maelstrom/project.go
+++ b/pkg/maelstrom/project.go
@@ -2,13 +2,14 @@ package maelstrom
 
 import (
 	"fmt"
-	"github.com/coopernurse/maelstrom/pkg/common"
-	"github.com/coopernurse/maelstrom/pkg/v1"
-	"github.com/go-yaml/yaml"
 	"io/ioutil"
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/coopernurse/maelstrom/pkg/common"
+	v1 "github.com/coopernurse/maelstrom/pkg/v1"
+	"github.com/go-yaml/yaml"
 )
 
 func PutProjectOutputEmpty(out v1.PutProjectOutput) bool {
@@ -148,6 +149,7 @@ type yamlComponent struct {
 	MaxInstances                int64
 	MaxInstancesPerNode         int64
 	MaxConcurrency              int64
+	SoftConcurrencyLimit        bool
 	ScaleDownConcurrencyPct     float64
 	ScaleUpConcurrencyPct       float64
 	MaxDurationSeconds          int64
@@ -248,6 +250,7 @@ func (c yamlComponent) toComponentWithEventSources(name string, projectName stri
 			MaxInstances:            c.MaxInstances,
 			MaxInstancesPerNode:     c.MaxInstancesPerNode,
 			MaxConcurrency:          c.MaxConcurrency,
+			SoftConcurrencyLimit:    c.SoftConcurrencyLimit,
 			MaxDurationSeconds:      c.MaxDurationSeconds,
 			ScaleDownConcurrencyPct: c.ScaleDownConcurrencyPct,
 			ScaleUpConcurrencyPct:   c.ScaleUpConcurrencyPct,

--- a/pkg/maelstrom/project_test.go
+++ b/pkg/maelstrom/project_test.go
@@ -1,9 +1,10 @@
 package maelstrom
 
 import (
-	"github.com/coopernurse/maelstrom/pkg/v1"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	v1 "github.com/coopernurse/maelstrom/pkg/v1"
+	"github.com/stretchr/testify/assert"
 )
 
 func newComponent(name string, image string, command ...string) v1.Component {
@@ -111,6 +112,7 @@ components:
     maxinstances: 5
     maxinstancespernode: 2
     maxconcurrency: 3
+    softconcurrencylimit: true
     maxdurationseconds: 30
     restartorder: startstop
   detector:
@@ -275,11 +277,12 @@ components:
 						Command:          []string{"python", "gizmo.py"},
 						LogDriverOptions: []v1.NameValue{},
 					},
-					MinInstances:        1,
-					MaxInstances:        5,
-					MaxInstancesPerNode: 2,
-					MaxConcurrency:      3,
-					MaxDurationSeconds:  30,
+					MinInstances:         1,
+					MaxInstances:         5,
+					MaxInstancesPerNode:  2,
+					MaxConcurrency:       3,
+					MaxDurationSeconds:   30,
+					SoftConcurrencyLimit: true,
 				},
 				EventSources: []v1.EventSourceWithStatus{},
 			},

--- a/pkg/revproxy/dispenser.go
+++ b/pkg/revproxy/dispenser.go
@@ -1,0 +1,80 @@
+package revproxy
+
+import (
+	"context"
+	"net/http/httputil"
+	"sync"
+	"time"
+)
+
+type Proxy func(req *Request)
+
+func NewGetProxyRequest() *GetProxyRequest {
+	return &GetProxyRequest{
+		Proxy: make(chan Proxy),
+	}
+}
+
+type GetProxyRequest struct {
+	Proxy chan Proxy
+}
+
+func NewDispenser(maxConcurrency int, reqCh <-chan *GetProxyRequest,
+	myNodeId string, componentName string, reqWaitGroup *sync.WaitGroup,
+	proxy *httputil.ReverseProxy, statCh chan<- time.Duration, ctx context.Context) *Dispenser {
+
+	doneChSize := maxConcurrency
+	if doneChSize < 1 {
+		doneChSize = 1
+	}
+	doneCh := make(chan bool, doneChSize)
+
+	proxyFx := func(req *Request) {
+		if reqWaitGroup != nil {
+			reqWaitGroup.Add(1)
+			defer reqWaitGroup.Done()
+		}
+		handleReq(req, myNodeId, componentName, proxy, statCh, ctx)
+		doneCh <- true
+	}
+
+	return &Dispenser{
+		maxConcurrency: maxConcurrency,
+		reqCh:          reqCh,
+		doneCh:         doneCh,
+		proxy:          proxyFx,
+	}
+}
+
+type Dispenser struct {
+	maxConcurrency int
+	reqCh          <-chan *GetProxyRequest
+	doneCh         chan bool
+	proxy          Proxy
+}
+
+func (d *Dispenser) Run(ctx context.Context) {
+	concur := 0
+	for {
+		if d.maxConcurrency < 1 || concur < d.maxConcurrency {
+			// under concurrency limit, accept a request, or a 'done' msg
+			select {
+			case <-ctx.Done():
+				return
+			case req := <-d.reqCh:
+				concur++
+				req.Proxy <- d.proxy
+			case <-d.doneCh:
+				concur--
+			}
+		} else {
+			// at limit - wait for 'done' msg
+			select {
+			case <-ctx.Done():
+				return
+			case <-d.doneCh:
+				concur--
+			}
+		}
+	}
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -3,15 +3,16 @@ package router
 import (
 	"context"
 	"fmt"
-	"github.com/coopernurse/maelstrom/pkg/revproxy"
-	v1 "github.com/coopernurse/maelstrom/pkg/v1"
-	log "github.com/mgutz/logxi/v1"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/coopernurse/maelstrom/pkg/revproxy"
+	v1 "github.com/coopernurse/maelstrom/pkg/v1"
+	log "github.com/mgutz/logxi/v1"
 )
 
 type StartComponentFunc func(componentName string)
@@ -58,8 +59,8 @@ type Router struct {
 	nodeId             string
 	startComponentFunc StartComponentFunc
 	state              State
-	remoteReqCh        chan *revproxy.Request
-	localReqCh         chan *revproxy.Request
+	remoteReqCh        chan *revproxy.GetProxyRequest
+	localReqCh         chan *revproxy.GetProxyRequest
 	inflightReqs       int64
 	activeHandlers     int64
 	bufferPool         *revproxy.ProxyBufferPool
@@ -164,23 +165,25 @@ func (r *Router) startRemoteHandler(targetUrl *url.URL, targetCount int) context
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
+	reqCh := r.HandlerStartRemote()
 	go func() {
-		reqCh := r.HandlerStartRemote()
 		defer r.HandlerStop()
-		revproxy.RevProxyLoop(reqCh, nil, proxy, ctx, nil, r.nodeId, r.componentName)
+		dispenser := revproxy.NewDispenser(targetCount, reqCh, r.nodeId,
+			r.componentName, nil, proxy, nil, ctx)
+		dispenser.Run(ctx)
 	}()
 	return cancelFunc
 }
 
-func (r *Router) HandlerStartRemote() (ch <-chan *revproxy.Request) {
+func (r *Router) HandlerStartRemote() (ch <-chan *revproxy.GetProxyRequest) {
 	return r.handlerStart(true)
 }
 
-func (r *Router) HandlerStartLocal() (ch <-chan *revproxy.Request) {
+func (r *Router) HandlerStartLocal() (ch <-chan *revproxy.GetProxyRequest) {
 	return r.handlerStart(false)
 }
 
-func (r *Router) handlerStart(remote bool) (ch <-chan *revproxy.Request) {
+func (r *Router) handlerStart(remote bool) (ch <-chan *revproxy.GetProxyRequest) {
 	r.lock.Lock()
 	r.activeHandlers++
 	if r.state != StateOn {
@@ -237,6 +240,9 @@ func (r *Router) Route(ctx context.Context, req *revproxy.Request) {
 	r.routeStart(req.Component)
 	defer r.routeDone()
 
+	haveProxy := false
+	getProxyReq := revproxy.NewGetProxyRequest()
+
 	if req.PreferLocal {
 		localSecs := req.Component.MaxDurationSeconds / 10
 		if localSecs < 1 {
@@ -244,9 +250,9 @@ func (r *Router) Route(ctx context.Context, req *revproxy.Request) {
 		}
 		timeout := time.After(time.Duration(localSecs) * time.Second)
 		select {
-		case r.localReqCh <- req:
+		case r.localReqCh <- getProxyReq:
 			// ok - done
-			return
+			haveProxy = true
 		case <-ctx.Done():
 			// timeout or shutdown
 			return
@@ -255,14 +261,21 @@ func (r *Router) Route(ctx context.Context, req *revproxy.Request) {
 		}
 	}
 
-	select {
-	case r.localReqCh <- req:
-		// ok
-	case r.remoteReqCh <- req:
-		// ok
-	case <-ctx.Done():
-		// timeout or shutdown
+	if !haveProxy {
+		select {
+		case r.localReqCh <- getProxyReq:
+			// ok
+		case r.remoteReqCh <- getProxyReq:
+			// ok
+		case <-ctx.Done():
+			// timeout or shutdown
+			return
+		}
 	}
+
+	// handle request
+	proxyFx := <-getProxyReq.Proxy
+	proxyFx(req)
 }
 
 func (r *Router) routeStart(comp *v1.Component) {
@@ -286,10 +299,10 @@ func (r *Router) routeDone() {
 
 func (r *Router) ensureReqChan() {
 	if r.remoteReqCh == nil {
-		r.remoteReqCh = make(chan *revproxy.Request)
+		r.remoteReqCh = make(chan *revproxy.GetProxyRequest)
 	}
 	if r.localReqCh == nil {
-		r.localReqCh = make(chan *revproxy.Request)
+		r.localReqCh = make(chan *revproxy.GetProxyRequest)
 	}
 }
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -165,8 +165,8 @@ func (r *Router) startRemoteHandler(targetUrl *url.URL, targetCount int) context
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
-	reqCh := r.HandlerStartRemote()
 	go func() {
+		reqCh := r.HandlerStartRemote()
 		defer r.HandlerStop()
 		dispenser := revproxy.NewDispenser(targetCount, reqCh, r.nodeId,
 			r.componentName, nil, proxy, nil, ctx)

--- a/pkg/v1/v1.go
+++ b/pkg/v1/v1.go
@@ -8,8 +8,8 @@ import (
 )
 
 const BarristerVersion string = "0.1.6"
-const BarristerChecksum string = "22ad1a00d9a67ee90aefa957418e3664"
-const BarristerDateGenerated int64 = 1580221399813000000
+const BarristerChecksum string = "21cf05cf7e2ddd0ce4d952c841cbb07d"
+const BarristerDateGenerated int64 = 1582655840550000000
 
 type EventSourceType string
 
@@ -61,6 +61,7 @@ type Component struct {
 	MaxInstances            int64            `json:"maxInstances,omitempty"`
 	MaxInstancesPerNode     int64            `json:"maxInstancesPerNode,omitempty"`
 	MaxConcurrency          int64            `json:"maxConcurrency"`
+	SoftConcurrencyLimit    bool             `json:"softConcurrencyLimit,omitempty"`
 	ScaleUpConcurrencyPct   float64          `json:"scaleUpConcurrencyPct,omitempty"`
 	ScaleDownConcurrencyPct float64          `json:"scaleDownConcurrencyPct,omitempty"`
 	MaxDurationSeconds      int64            `json:"maxDurationSeconds,omitempty"`
@@ -1415,6 +1416,13 @@ var IdlJsonRaw = `[
                 "optional": false,
                 "is_array": false,
                 "comment": "Maximum concurrent requests to proxy to a single instance of this component"
+            },
+            {
+                "name": "softConcurrencyLimit",
+                "type": "bool",
+                "optional": true,
+                "is_array": false,
+                "comment": "If true, maxConcurrency will be used to autoscale the component, but will not\ncause requests exceeding the limit to queue (default=false)"
             },
             {
                 "name": "scaleUpConcurrencyPct",
@@ -3721,7 +3729,7 @@ var IdlJsonRaw = `[
         "values": null,
         "functions": null,
         "barrister_version": "0.1.6",
-        "date_generated": 1580221399813,
-        "checksum": "22ad1a00d9a67ee90aefa957418e3664"
+        "date_generated": 1582655840550,
+        "checksum": "21cf05cf7e2ddd0ce4d952c841cbb07d"
     }
 ]`


### PR DESCRIPTION
If this is true, the maxconcurrency value will only be used to
autoscale the component, but will not be used as a hard limit by
the reverse proxy. That is, the limit may be exceeded.

This is useful for cases if a component is used in a request cycle
where a hard limit would potentially cause deadlocks.