### PR TITLE
maelstromd: fixes for shutdown sequence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf
+	github.com/kr/pretty v0.2.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.2.0
@@ -35,6 +36,8 @@ require (
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b
 	golang.org/x/oauth2 v0.0.0-20190523182746-aaccbc9213b0
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,11 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/klauspost/cpuid v1.2.0 h1:NMpwD2G9JSFOE1/TJjGSo5zG7Yb2bTe7eq1jH+irmeE=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
@@ -102,5 +107,10 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/square/go-jose.v2 v2.2.2 h1:orlkJ3myw8CN1nVQHBFfloD+L3egixIa4FvUP6RosSA=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/converge/container.go
+++ b/pkg/converge/container.go
@@ -192,8 +192,9 @@ func (c *Container) run() {
 	go func() {
 		defer c.router.HandlerStop()
 		dispenser := revproxy.NewDispenser(maxConcurRevProxy, reqCh, "",
-			"", c.revProxyWg, c.proxy, c.statCh, c.revProxyCtx)
-		dispenser.Run(c.ctx)
+			"", c.proxy, c.statCh, c.revProxyCtx)
+		c.revProxyWg.Add(1)
+		dispenser.Run(c.revProxyCtx, c.revProxyWg)
 	}()
 
 	healthCheckSecs := c.component.Docker.HttpHealthCheckSeconds

--- a/pkg/converge/registry.go
+++ b/pkg/converge/registry.go
@@ -2,6 +2,9 @@ package converge
 
 import (
 	"context"
+	"sync"
+	"time"
+
 	"github.com/coopernurse/maelstrom/pkg/common"
 	"github.com/coopernurse/maelstrom/pkg/revproxy"
 	"github.com/coopernurse/maelstrom/pkg/router"
@@ -9,8 +12,6 @@ import (
 	docker "github.com/docker/docker/client"
 	log "github.com/mgutz/logxi/v1"
 	"github.com/pkg/errors"
-	"sync"
-	"time"
 )
 
 func NewRegistry(dockerClient *docker.Client, routerReg *router.Registry, maelstromUrl string,
@@ -73,10 +74,10 @@ func (r *Registry) Shutdown() {
 	wg := &sync.WaitGroup{}
 	for _, c := range r.byCompName {
 		wg.Add(1)
-		go func() {
+		go func(conv *Converger) {
 			defer wg.Done()
-			c.Stop()
-		}()
+			conv.Stop()
+		}(c)
 	}
 	wg.Wait()
 	r.byCompName = make(map[string]*Converger)

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -169,8 +169,8 @@ func (r *Router) startRemoteHandler(targetUrl *url.URL, targetCount int) context
 		reqCh := r.HandlerStartRemote()
 		defer r.HandlerStop()
 		dispenser := revproxy.NewDispenser(targetCount, reqCh, r.nodeId,
-			r.componentName, nil, proxy, nil, ctx)
-		dispenser.Run(ctx)
+			r.componentName, proxy, nil, ctx)
+		dispenser.Run(ctx, nil)
 	}()
 	return cancelFunc
 }


### PR DESCRIPTION
* have Dispenser.Run block until all in flight requests complete
* remove WaitGroup Add/Done from Dispenser proxyFx
* registry: fix Shutdown loop to ensure all components are stopped
* node_svc: return error from StartStopComponents if node is in
  terminating state. This prevents the caller from re-adding the
  node to its route table.