### PR TITLE
maelstromd: use custom http client with aws session

### DIFF
--- a/cmd/maelstromd/maelstromd.go
+++ b/cmd/maelstromd/maelstromd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/coopernurse/barrister-go"
 	"github.com/coopernurse/maelstrom/pkg/cert"
@@ -165,7 +166,18 @@ func main() {
 
 	resolver := maelstrom.NewDbResolver(db, certWrapper, time.Second)
 
-	awsSession, err := session.NewSession()
+	awsSession, err := session.NewSession(&aws.Config{
+		HTTPClient: common.NewHTTPClientWithSettings(common.HTTPClientSettings{
+			ConnectTimeout:        15 * time.Second,
+			ExpectContinue:        1 * time.Second,
+			IdleConnTimeout:       50 * time.Second,
+			ConnKeepAlive:         30 * time.Second,
+			MaxAllIdleConns:       100,
+			MaxHostIdleConns:      10,
+			ResponseHeaderTimeout: 90 * time.Second,
+			TLSHandshakeTimeout:   15 * time.Second,
+		}),
+	})
 	if err != nil {
 		log.Warn("maelstromd: unable to init aws session", "err", err.Error())
 	}

--- a/cmd/maelstromd/maelstromd.go
+++ b/cmd/maelstromd/maelstromd.go
@@ -166,18 +166,21 @@ func main() {
 
 	resolver := maelstrom.NewDbResolver(db, certWrapper, time.Second)
 
-	awsSession, err := session.NewSession(&aws.Config{
-		HTTPClient: common.NewHTTPClientWithSettings(common.HTTPClientSettings{
-			ConnectTimeout:        15 * time.Second,
-			ExpectContinue:        1 * time.Second,
-			IdleConnTimeout:       50 * time.Second,
-			ConnKeepAlive:         30 * time.Second,
-			MaxAllIdleConns:       100,
-			MaxHostIdleConns:      10,
-			ResponseHeaderTimeout: 90 * time.Second,
-			TLSHandshakeTimeout:   15 * time.Second,
-		}),
+	awsHttpClient, err := common.NewHTTPClientWithSettings(common.HTTPClientSettings{
+		ConnectTimeout:        15 * time.Second,
+		ExpectContinue:        1 * time.Second,
+		IdleConnTimeout:       50 * time.Second,
+		ConnKeepAlive:         30 * time.Second,
+		MaxAllIdleConns:       100,
+		MaxHostIdleConns:      10,
+		ResponseHeaderTimeout: 90 * time.Second,
+		TLSHandshakeTimeout:   15 * time.Second,
 	})
+	if err != nil {
+		log.Error("maelstromd: cannot create aws http client", "err", err)
+		os.Exit(2)
+	}
+	awsSession, err := session.NewSession(&aws.Config{HTTPClient: awsHttpClient})
 	if err != nil {
 		log.Warn("maelstromd: unable to init aws session", "err", err.Error())
 	}

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b
+	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
 	golang.org/x/oauth2 v0.0.0-20190523182746-aaccbc9213b0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect

--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"golang.org/x/net/http2"
+	"net"
+	"net/http"
+	"time"
+)
+
+type HTTPClientSettings struct {
+	ConnectTimeout        time.Duration
+	ConnKeepAlive         time.Duration
+	ExpectContinue        time.Duration
+	IdleConnTimeout       time.Duration
+	MaxAllIdleConns       int
+	MaxHostIdleConns      int
+	ResponseHeaderTimeout time.Duration
+	TLSHandshakeTimeout   time.Duration
+}
+
+func NewHTTPClientWithSettings(httpSettings HTTPClientSettings) *http.Client {
+	tr := &http.Transport{
+		ResponseHeaderTimeout: httpSettings.ResponseHeaderTimeout,
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			KeepAlive: httpSettings.ConnKeepAlive,
+			DualStack: true,
+			Timeout:   httpSettings.ConnectTimeout,
+		}).DialContext,
+		MaxIdleConns:          httpSettings.MaxAllIdleConns,
+		IdleConnTimeout:       httpSettings.IdleConnTimeout,
+		TLSHandshakeTimeout:   httpSettings.TLSHandshakeTimeout,
+		MaxIdleConnsPerHost:   httpSettings.MaxHostIdleConns,
+		ExpectContinueTimeout: httpSettings.ExpectContinue,
+	}
+
+	// So client makes HTTP/2 requests
+	http2.ConfigureTransport(tr)
+
+	return &http.Client{
+		Transport: tr,
+	}
+}

--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -18,7 +18,7 @@ type HTTPClientSettings struct {
 	TLSHandshakeTimeout   time.Duration
 }
 
-func NewHTTPClientWithSettings(httpSettings HTTPClientSettings) *http.Client {
+func NewHTTPClientWithSettings(httpSettings HTTPClientSettings) (*http.Client, error) {
 	tr := &http.Transport{
 		ResponseHeaderTimeout: httpSettings.ResponseHeaderTimeout,
 		Proxy:                 http.ProxyFromEnvironment,
@@ -35,9 +35,12 @@ func NewHTTPClientWithSettings(httpSettings HTTPClientSettings) *http.Client {
 	}
 
 	// So client makes HTTP/2 requests
-	http2.ConfigureTransport(tr)
+	err := http2.ConfigureTransport(tr)
+	if err != nil {
+		return nil, err
+	}
 
 	return &http.Client{
 		Transport: tr,
-	}
+	}, nil
 }


### PR DESCRIPTION
Also, small patch to SQS to log 'RequestCanceled' errors as warnings (this always happens at shutdown)